### PR TITLE
Pass on options

### DIFF
--- a/lib/generic_form_builder.rb
+++ b/lib/generic_form_builder.rb
@@ -14,7 +14,7 @@ class GenericFormBuilder < ActionView::Helpers::FormBuilder
       note   = content_tag(:span, options[:note], :class => 'note') if options[:note]
       button = ' '+content_tag(:button, content_tag(:span, options[:button])) if options[:button]
       errors = ' '+@object.errors[field].join(' and ') if @object.errors[field].any?
-      content_tag(:p, label(field, "#{options[:label]}#{errors}") + note + super(field, *args) + button.try(:html_safe))
+      content_tag(:p, label(field, "#{options[:label]}#{errors}") + note + super(field, options, *args) + button.try(:html_safe))
     end
   end
 


### PR DESCRIPTION
God damnit Elliot.

This patch makes your shit pass on any options it doesn't recognise to the super() call. Which means that if you specify e.g. size on a text field:

<code>f.text_field :email, :size => 15</code>

It actually gets that size.

I couldn't work out quickly how to make it work for the other kinds of fields, or perhaps I was just too lazy. You should do that.
