### PR TITLE
allow to use the original form builder without nesting in parameter etc.

### DIFF
--- a/lib/generic_form_builder.rb
+++ b/lib/generic_form_builder.rb
@@ -21,21 +21,25 @@ class GenericFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select(field, collection, options = {}, html_options = {})
+    return super if options[:default_builder]
     label_text = options[:label] || field.to_s.humanize
     content_tag(:p, label(field, "#{label_text} #{errors_text(field)}") + super)
   end
 
   def collection_select(field, collection, value_method, name_method, options = {}, html_options = {})
+    return super(field, collection, value_method, name_method) if options[:default_builder]
     label_text = options[:label] || field.to_s.humanize
     content_tag(:p, label(field, "#{label_text} #{errors_text(field)}") + super(field, collection, value_method, name_method))
   end
 
   def check_box(field, options = {})
+    return super if options[:default_builder]
     label_text = options[:label] || field.to_s.humanize
     content_tag(:p, label(field, super + " #{label_text} #{errors_text(field)}", :class => 'checkbox'))
   end
 
   def radio_button(field, value, options = {})
+    return super if options[:default_builder]
     label_text = options.delete(:label) || field.to_s.humanize
     options[:tag_type] ||= :li
     content_tag(options[:tag_type], label(field, super + " #{label_text} #{errors_text(field)}"))


### PR DESCRIPTION
This is necessary if you want something different, like 3 fields on the same line.
