### PR TITLE
Style error messages for select fields

### DIFF
--- a/lib/generic_form_builder.rb
+++ b/lib/generic_form_builder.rb
@@ -20,11 +20,10 @@ class GenericFormBuilder < ActionView::Helpers::FormBuilder
       html_options = {}
 
       if any_errors?(field)
-        errors = ' '+content_tag(:span, errors_text(field), :class => "error")
         html_options.merge!('class' => 'errors')
       end
 
-      content_tag(:p, label(field, "#{options[:label] || field.to_s.humanize}#{errors}".try(:html_safe)) + note + super(field, options, *args) + button.try(:html_safe), html_options)
+      content_tag(:p, label(field, "#{options[:label] || field.to_s.humanize} #{errors_text(field)}".try(:html_safe)) + note + super(field, options, *args) + button.try(:html_safe), html_options)
     end
   end
 
@@ -32,28 +31,32 @@ class GenericFormBuilder < ActionView::Helpers::FormBuilder
     return super if options[:default_builder]
     label_text = options[:label] || field.to_s.humanize
     note       = note_html(options[:note])
-    content_tag(:p, label(field, "#{label_text} #{errors_text(field)}") + note + super)
+    p_html_options = {}
+    if any_errors?(field)
+      p_html_options.merge!('class' => 'errors')
+    end
+    content_tag(:p, label(field, "#{label_text} #{errors_text(field)}".try(:html_safe)) + note + super, p_html_options)
   end
 
   def collection_select(field, collection, value_method, name_method, options = {}, html_options = {})
     return super(field, collection, value_method, name_method) if options[:default_builder]
     label_text = options[:label] || field.to_s.humanize
     note       = note_html(options[:note])
-    content_tag(:p, label(field, "#{label_text} #{errors_text(field)}") + note + super(field, collection, value_method, name_method))
+    content_tag(:p, label(field, "#{label_text} #{errors_text(field)}".try(:html_safe)) + note + super(field, collection, value_method, name_method))
   end
 
   def check_box(field, options = {})
     return super if options[:default_builder]
     label_text = options[:label] || field.to_s.humanize
     note       = note_html(options[:note])
-    content_tag(:p, label(field, super + " #{label_text} #{errors_text(field)}" + note, :class => 'checkbox'))
+    content_tag(:p, label(field, super + " #{label_text} #{errors_text(field)}".try(:html_safe) + note, :class => 'checkbox'))
   end
 
   def radio_button(field, value, options = {})
     return super if options[:default_builder]
     label_text = options.delete(:label) || field.to_s.humanize
     tag_type = options.delete(:tag_type) || :li
-    content_tag(tag_type, label("#{field}_#{value.to_s.downcase.gsub(' ', '_')}", super + " #{label_text} #{errors_text(field)}", :class => 'radio', :onclick => ""))
+    content_tag(tag_type, label("#{field}_#{value.to_s.downcase.gsub(' ', '_')}", super + " #{label_text} #{errors_text(field)}".try(:html_safe), :class => 'radio', :onclick => ""))
   end
 
   def buttons(options = {})
@@ -71,7 +74,7 @@ protected
 
   def errors_text(field)
     return '' unless any_errors?(field)
-    @object.errors[field].join(' and ')
+    content_tag(:span, @object.errors[field].join(' and '), :class => "error")
   end
 
   def note_html(note)


### PR DESCRIPTION
move adding of error class span to error message to errors_text method
so everything can use it.

Add errors class to wrapping p for select method. Should probably do it
to the rest too, but wary of touching too much in this gem as not sure
what else uses it.